### PR TITLE
Add a configuration option to specify the minimum number of argument order violations that must be present for problems to be registered with a call.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.jfarrelly.intellij.plugin'
-version '1.0.1'
+version '1.1.0-SNAPSHOT'
 
 repositories {
   mavenCentral()

--- a/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderInspection.java
+++ b/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderInspection.java
@@ -1,28 +1,27 @@
 package com.jfarrelly.intellij.plugin.code.inspection;
 
-import javax.swing.JComponent;
-
-import org.jetbrains.annotations.NotNull;
-
 import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.codeInspection.ui.SingleIntegerFieldOptionsPanel;
 import com.intellij.psi.PsiElementVisitor;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
 
 public class MethodParameterOrderInspection extends AbstractBaseJavaLocalInspectionTool {
 
-  public int minIncorrectParameters = 2;
+  public int minOutOfOrderArguments = 2;
 
   @NotNull
   @Override
   public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
-    return new MethodParameterOrderVisitor(holder, minIncorrectParameters);
+    return new MethodParameterOrderVisitor(holder, minOutOfOrderArguments);
   }
 
   @NotNull
   @Override
   public JComponent createOptionsPanel() {
     return new SingleIntegerFieldOptionsPanel(
-        "Minimum incorrect parameters", this, "minIncorrectParameters");
+            "Minimum out-of-order arguments", this, "minOutOfOrderArguments");
   }
 }

--- a/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderInspection.java
+++ b/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderInspection.java
@@ -1,16 +1,28 @@
 package com.jfarrelly.intellij.plugin.code.inspection;
 
+import javax.swing.JComponent;
+
 import org.jetbrains.annotations.NotNull;
 
 import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool;
 import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.codeInspection.ui.SingleIntegerFieldOptionsPanel;
 import com.intellij.psi.PsiElementVisitor;
 
 public class MethodParameterOrderInspection extends AbstractBaseJavaLocalInspectionTool {
 
+  public int minIncorrectParameters = 2;
+
   @NotNull
   @Override
   public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
-    return new MethodParameterOrderVisitor(holder);
+    return new MethodParameterOrderVisitor(holder, minIncorrectParameters);
+  }
+
+  @NotNull
+  @Override
+  public JComponent createOptionsPanel() {
+    return new SingleIntegerFieldOptionsPanel(
+        "Minimum incorrect parameters", this, "minIncorrectParameters");
   }
 }

--- a/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderInspection.java
+++ b/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderInspection.java
@@ -1,12 +1,13 @@
 package com.jfarrelly.intellij.plugin.code.inspection;
 
+import javax.swing.JComponent;
+
+import org.jetbrains.annotations.NotNull;
+
 import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.codeInspection.ui.SingleIntegerFieldOptionsPanel;
 import com.intellij.psi.PsiElementVisitor;
-import org.jetbrains.annotations.NotNull;
-
-import javax.swing.*;
 
 public class MethodParameterOrderInspection extends AbstractBaseJavaLocalInspectionTool {
 
@@ -22,6 +23,6 @@ public class MethodParameterOrderInspection extends AbstractBaseJavaLocalInspect
   @Override
   public JComponent createOptionsPanel() {
     return new SingleIntegerFieldOptionsPanel(
-            "Minimum out-of-order arguments", this, "minOutOfOrderArguments");
+        "Minimum out-of-order arguments", this, "minOutOfOrderArguments");
   }
 }

--- a/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderVisitor.java
+++ b/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderVisitor.java
@@ -1,25 +1,33 @@
 package com.jfarrelly.intellij.plugin.code.inspection;
 
-import com.intellij.codeInspection.ProblemsHolder;
-import com.intellij.openapi.util.Pair;
-import com.intellij.psi.*;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.openapi.util.Pair;
+import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiCall;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiExpression;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiMethodCallExpression;
+import com.intellij.psi.PsiNamedElement;
+import com.intellij.psi.PsiParameter;
+
 public class MethodParameterOrderVisitor extends JavaElementVisitor {
 
-    private static final String DESCRIPTION_TEMPLATE = "Argument '%s' in different order than '%s' parameter on method '%s'";
-    private static final int MIN_ARGUMENTS = 2;
+  private static final String DESCRIPTION_TEMPLATE = "Argument '%s' in different order than '%s' parameter on method '%s'";
+  private static final int MIN_ARGUMENTS = 2;
 
-    private final ProblemsHolder holder;
-    private final int minOutOfOrderArguments;
+  private final ProblemsHolder holder;
+  private final int minOutOfOrderArguments;
 
-    public MethodParameterOrderVisitor(ProblemsHolder holder, int minOutOfOrderArguments) {
+  public MethodParameterOrderVisitor(ProblemsHolder holder, int minOutOfOrderArguments) {
         this.holder = holder;
         this.minOutOfOrderArguments = minOutOfOrderArguments;
     }

--- a/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderVisitor.java
+++ b/src/main/java/com/jfarrelly/intellij/plugin/code/inspection/MethodParameterOrderVisitor.java
@@ -9,7 +9,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.openapi.util.Pair;
 import com.intellij.psi.JavaElementVisitor;
+import com.intellij.psi.PsiCall;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiExpression;
 import com.intellij.psi.PsiMethod;
@@ -19,13 +21,16 @@ import com.intellij.psi.PsiParameter;
 
 public class MethodParameterOrderVisitor extends JavaElementVisitor {
 
-  private static final String DESCRIPTION_TEMPLATE = "Argument '%s' in different order than '%s' parameter on method '%s'";
+  private static final String DESCRIPTION_TEMPLATE =
+      "Argument '%s' in different order than '%s' parameter on method '%s'";
   private static final int MIN_ARGUMENTS = 2;
 
   private final ProblemsHolder holder;
+  private final int minIncorrectParameters;
 
-  public MethodParameterOrderVisitor(ProblemsHolder holder) {
+  public MethodParameterOrderVisitor(ProblemsHolder holder, int minIncorrectParameters) {
     this.holder = holder;
+    this.minIncorrectParameters = minIncorrectParameters;
   }
 
   @Override
@@ -36,7 +41,8 @@ public class MethodParameterOrderVisitor extends JavaElementVisitor {
       return;
     }
 
-    List<String> argumentNames = new ArrayList<>(methodCallExpression.getArgumentList().getExpressionCount());
+    List<String> argumentNames =
+        new ArrayList<>(methodCallExpression.getArgumentList().getExpressionCount());
     for (PsiExpression argument : methodCallExpression.getArgumentList().getExpressions()) {
       argumentNames.add(getArgumentName(argument));
     }
@@ -44,31 +50,53 @@ public class MethodParameterOrderVisitor extends JavaElementVisitor {
     if (hasNonNullElements(argumentNames, MIN_ARGUMENTS)) {
       PsiMethod calledMethod = methodCallExpression.resolveMethod();
       if (calledMethod != null) {
-        int nParametersToCheck = Math.min(calledMethod.getParameterList().getParametersCount(), argumentNames.size());
-        for (int parameterPosition = 0; parameterPosition < nParametersToCheck; parameterPosition++) {
+        int nParametersToCheck =
+            Math.min(calledMethod.getParameterList().getParametersCount(), argumentNames.size());
+        List<Pair<PsiElement, String>> problems = new ArrayList<>(nParametersToCheck);
+        for (int parameterPosition = 0;
+             parameterPosition < nParametersToCheck;
+             parameterPosition++) {
           PsiParameter parameter = calledMethod.getParameterList().getParameter(parameterPosition);
           if (parameter != null) {
-            checkParameterPosition(argumentNames, parameterPosition, parameter, methodCallExpression);
+            Pair<PsiElement, String> problem =
+                checkParameterPosition(
+                    argumentNames, parameterPosition, parameter, methodCallExpression);
+            if (problem != null) {
+              problems.add(problem);
+            }
+          }
+        }
+        if (problems.size() >= minIncorrectParameters) {
+          for (Pair<PsiElement, String> problem : problems) {
+            holder.registerProblem(problem.first, problem.second);
           }
         }
       }
     }
   }
 
-  private void checkParameterPosition(@NotNull List<String> argumentNames, int parameterPosition, @NotNull PsiParameter parameter, @NotNull PsiMethodCallExpression methodCallExpression) {
+  @Nullable
+  private static Pair<PsiElement, String> checkParameterPosition(
+      @NotNull List<String> argumentNames,
+      int parameterPosition,
+      @NotNull PsiParameter parameter,
+      @NotNull PsiMethodCallExpression methodCallExpression) {
     String parameterName = toLower(parameter);
     if (!Objects.equals(parameterName, argumentNames.get(parameterPosition))) {
       int argumentPosition = argumentNames.indexOf(parameterName);
       if (argumentPosition != -1 && argumentPosition != parameterPosition) {
-        PsiExpression argument = methodCallExpression.getArgumentList().getExpressions()[argumentPosition];
-        holder.registerProblem(argument,
-            String.format(DESCRIPTION_TEMPLATE,
+        PsiExpression argument =
+            methodCallExpression.getArgumentList().getExpressions()[argumentPosition];
+        return Pair.create(
+            argument,
+            String.format(
+                DESCRIPTION_TEMPLATE,
                 argument.getText(),
                 parameter.getName(),
-                methodCallExpression.getMethodExpression().getText()
-            ));
+                methodCallExpression.getMethodExpression().getText()));
       }
     }
+    return null;
   }
 
   @Nullable
@@ -76,7 +104,7 @@ public class MethodParameterOrderVisitor extends JavaElementVisitor {
     if (argument.getReference() != null) {
       return toLower(argument.getReference().getElement());
     } else if (argument instanceof PsiMethodCallExpression) {
-      PsiMethod method = ((PsiMethodCallExpression) argument).resolveMethod();
+      PsiMethod method = ((PsiCall) argument).resolveMethod();
       return toAttributeName(method);
     }
     return null;

--- a/src/main/resources/inspectionDescriptions/MethodParameterOrder.html
+++ b/src/main/resources/inspectionDescriptions/MethodParameterOrder.html
@@ -1,30 +1,26 @@
-<html lang="en">
+<html>
 <body>
-Arguments that are passed into a method call in the wrong order can lead to hard-to-spot bugs in code. When these method parameters are of the same type, the compiler will not warn you that you have
-passed them in the wrong order, and no static analysis tool currently highlight this issue.
-<p>
-  This IntelliJ plugin adds a new code inspection under <b>Java &gt; Probable Bugs</b>: <b>Parameters should be passed in the correct order</b>
-</p>
-<p>
-  Running a code analysis on you project with this inspection enabled will highlight places where you may be passing parameters in the wrong order.
-</p>
-<b>Example</b>
-You have a method:
-<code>
-public void insert(String firstName, String lastName) {
-    db.savePerson(firstName, lastName);
-}
-</code>
+Arguments that are passed into a method call in the wrong order can lead to hard-to-spot bugs in code. When these method
+parameters are of the same type, the compiler will not warn you that you have passed them in the wrong order, and no
+static analysis tool currently highlight this issue.
 
+Running a code analysis on you project with this inspection enabled will highlight places where you may be passing
+parameters in the wrong order. For example:
+<!-- tooltip end -->
+<pre><code>
+  public void insert(String firstName, String lastName) {
+    db.savePerson(firstName, lastName);
+  }
+</code></pre>
 However, in one part of your code, you have accidentally passed the arguments in the wrong order:
-<code>
-insert(lastName, firstName);
-</code>
+<pre><code>
+  insert(lastName, firstName);
+</code></pre>
+The compier will not complain, because both arguments are the same type: String. Running a code analysis with this
+plugin installed will warn that you are passing arguments in the wrong order.
 <p>
-  The compier will not complain, because both arguments are the same type: <code>String</code>.
-</p>
+    Use the field below to to specify the minimum number of argument order violations that must be present for problems
+    to be registered with a call.
 <p>
-  Running a code analysis with this plugin installed will warn that you are passing arguments in the wrong order.
-</p>
 </body>
 </html>

--- a/src/test/java/com/jfarrelly/intellij/plugin/code/inspection/Examples.java
+++ b/src/test/java/com/jfarrelly/intellij/plugin/code/inspection/Examples.java
@@ -1,0 +1,55 @@
+package com.jfarrelly.intellij.plugin.code.inspection;
+
+import java.util.Arrays;
+
+class Examples {
+  private String getFullName(String firstName, String lastName) {
+    return firstName + " " + lastName;
+  }
+
+  private String getLegalName(String firstName, String middleName, String... lastNames) {
+    return firstName + " " + middleName + " " + Arrays.toString(lastNames);
+  }
+
+  private void checkVariables() {
+    String firstName = "IntelliJ";
+    String middleName = "JetBrains";
+    String lastName = "IDEA";
+
+    // NO PROBLEMS: Parameters in correct order
+    getFullName(firstName, lastName);
+    getFullName(firstName, firstName);
+    getFullName(lastName, lastName);
+    getLegalName(firstName, middleName);
+    getLegalName(firstName, middleName, lastName);
+
+    // PROBLEMS: Parameters in wrong order
+    getFullName(lastName, firstName);
+    getLegalName(middleName, firstName);
+    getLegalName(firstName, lastName, middleName);
+  }
+
+  private void checkMethods() {
+    // NO PROBLEMS: Parameters in correct order
+    getFullName(getFirstName(), getLastName());
+    getFullName(getFirstName(), getFirstName());
+    getFullName(getLastName(), getLastName());
+
+    Person person = new Person(getFirstName(), getLastName());
+    getFullName(person.getFirstName(), person.getLastName());
+    getFullName(person.getFirstName(), person.getFirstName());
+    getFullName(person.getLastName(), person.getLastName());
+
+    // PROBLEMS: Parameters in wrong order
+    getFullName(getLastName(), getFirstName());
+    getFullName(person.getLastName(), person.getFirstName());
+  }
+
+  private String getFirstName() {
+    return "IntelliJ";
+  }
+
+  private String getLastName() {
+    return "IDEA";
+  }
+}

--- a/src/test/java/com/jfarrelly/intellij/plugin/code/inspection/Person.java
+++ b/src/test/java/com/jfarrelly/intellij/plugin/code/inspection/Person.java
@@ -1,0 +1,19 @@
+package com.jfarrelly.intellij.plugin.code.inspection;
+
+public class Person {
+  private final String firstName;
+  private final String lastName;
+
+  public Person(String firstName, String lastName) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+}


### PR DESCRIPTION
There are a lot of "false positives" being detected by this plugin - if a single method argument is out of order in a call, a problem will be reported.  However, in the majority of these cases it is not actually an error.

This PR adds a configuration option to specify the minimum number of argument order violations that must be present for problems to be registered with a call.  The default is 2, as in the majority of real problem cases, 2 or more arguments are in the wrong order in a method call.